### PR TITLE
docs: Fix simple typo, dispath -> dispatch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ pyramid_pages
 
 **pyramid_pages** provides a collections of pages to your Pyramid application.
 This is very similar to **django.contrib.flatpages** but with a tree structure
-and traversal algorithm in URL dispath.
+and traversal algorithm in URL dispatch.
 
 See documentation http://pyramid-pages.readthedocs.io
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ pyramid_pages
 
 **pyramid_pages** provides a collections of pages to your Pyramid application.
 This is very similar to **django.contrib.flatpages** but with a tree structure
-and traversal algorithm in URL dispath.
+and traversal algorithm in URL dispatch.
 
 .. image:: _static/img/example.png
     :alt: pyramid_pages - example of website pages tree

--- a/pyramid_pages/resources.py
+++ b/pyramid_pages/resources.py
@@ -40,7 +40,7 @@ class BasePageResource(object):
     def __init__(self,
                  node, prefix=None, request=None, parent=None,
                  *args, **kwargs):
-        """ Make resource of node for traversal URL dispath.
+        """ Make resource of node for traversal URL dispatch.
 
         :node: instance of page
         :pages_config: config for pyramid_pages from your app


### PR DESCRIPTION
There is a small typo in README.rst, docs/index.rst, pyramid_pages/resources.py.

Should read `dispatch` rather than `dispath`.

